### PR TITLE
Edits to the Secret Evaluation Workflow

### DIFF
--- a/.github/workflows/secret_assignment_eval.yml
+++ b/.github/workflows/secret_assignment_eval.yml
@@ -109,11 +109,13 @@ jobs:
           apt-get update && apt-get install -y git
 
       - name: Install Python dependencies
+        if: needs.secret-test.outputs.secret_exists == 'true'
         run: |
           pip install requests uuid
 
       - name: Generate secret code
         id: generate-code
+        if: needs.secret-test.outputs.secret_exists == 'true'
         run: |
           SECRET_CODE=$(python .github/workflows/scripts/generate_secret_code.py)
           echo "Generated Secret Code: $SECRET_CODE"

--- a/.github/workflows/secret_assignment_eval.yml
+++ b/.github/workflows/secret_assignment_eval.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
 jobs:
-   secret-test:
+  secret-test:
     runs-on: ubuntu-latest
     container:
       image: maniator/gh
@@ -19,6 +19,11 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    outputs:
+      issue_found: ${{ steps.find-issue.outputs.issue_found }}
+      issue_number: ${{ steps.find-issue.outputs.issue_number }}
+      secret_name: ${{ steps.check-secret.outputs.secret_name }}
+      secret_exists: ${{ steps.check-secret.outputs.secret_exists }}
 
     steps:
       # Step 1: Checkout the files here.
@@ -84,31 +89,55 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install uv
-        if: steps.check-secret.outputs.secret_exists == 'true' && steps.find-issue.outputs.issue_found == 'true'
-        uses: astral-sh/setup-uv@v5
+  generate-code-for-comment:
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.11-slim
+    needs: secret-test
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      secret_code: ${{ steps.generate-code.outputs.secret_code }}
 
-      - name: Install dependencies
-        if: steps.check-secret.outputs.secret_exists == 'true' && steps.find-issue.outputs.issue_found == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install git (required for actions)
         run: |
-          uv pip install --system requests uuid
+          apt-get update && apt-get install -y git
+
+      - name: Install Python dependencies
+        run: |
+          pip install requests uuid
 
       - name: Generate secret code
         id: generate-code
-        if: steps.check-secret.outputs.secret_exists == 'true' && steps.find-issue.outputs.issue_found == 'true'
         run: |
           SECRET_CODE=$(python .github/workflows/scripts/generate_secret_code.py)
           echo "Generated Secret Code: $SECRET_CODE"
           echo "secret_code=$SECRET_CODE" >> $GITHUB_OUTPUT
-        shell: bash
 
+  comment:
+    runs-on: ubuntu-latest
+    container:
+      image: maniator/gh
+    needs: [secret-test, generate-code-for-comment]
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
       # --- Comment on Issue (SUCCESS case) ---
       - name: Comment secret code on Issue (Success)
-        if: steps.check-secret.outputs.secret_exists == 'true' && steps.find-issue.outputs.issue_found == 'true'
+        if: needs.secret-test.outputs.secret_exists == 'true' && needs.secret-test.outputs.issue_found == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ steps.find-issue.outputs.issue_number }}
+          issue-number: ${{ needs.secret-test.outputs.issue_number }}
           body: |
             🎉 **GitHub Secret Successfully Configured!** 🎉
 
@@ -117,14 +146,14 @@ jobs:
             **Workflow Dispatch:** ✅ Successfully used workflow_dispatch trigger
 
             Excellent work! You have successfully:
-            - ✅ Created the GitHub secret `${{ steps.check-secret.outputs.secret_name }}`
+            - ✅ Created the GitHub secret `${{ needs.secret-test.outputs.secret_name }}`
             - ✅ Used workflow_dispatch to trigger this evaluation
             - ✅ Secret is accessible to GitHub Actions
 
             Here's your completion code:
 
             ```
-            ${{ steps.generate-code.outputs.secret_code }}
+            ${{ needs.generate-code-for-comment.outputs.secret_code }}
             ```
 
             **What you accomplished:**
@@ -138,11 +167,11 @@ jobs:
 
       # --- Comment on Issue (SECRET NOT FOUND case) ---
       - name: Comment on Issue (Secret Not Found)
-        if: steps.check-secret.outputs.secret_exists == 'false' && steps.find-issue.outputs.issue_found == 'true'
+        if: needs.secret-test.outputs.secret_exists == 'false' && needs.secret-test.outputs.issue_found == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ steps.find-issue.outputs.issue_number }}
+          issue-number: ${{ needs.secret-test.outputs.issue_number }}
           body: |
             ⚠️ **GitHub Secret Not Found** ⚠️
 
@@ -150,14 +179,14 @@ jobs:
             **Triggered by:** @${{ github.actor }}
             **Workflow Dispatch:** ✅ Successfully used workflow_dispatch trigger
 
-            Great job using workflow_dispatch! However, I couldn't find the required GitHub secret `${{ steps.check-secret.outputs.secret_name }}` in your repository.
+            Great job using workflow_dispatch! However, I couldn't find the required GitHub secret `${{ needs.secret-test.outputs.secret_name }}` in your repository.
 
             **To complete this assignment, please:**
 
             1. **Go to your repository Settings** (⚙️ tab at the top)
             2. **Navigate to "Secrets and variables" → "Actions"** (in the left sidebar)
             3. **Click "New repository secret"** (green button)
-            4. **Set the name to:** `${{ steps.check-secret.outputs.secret_name }}`
+            4. **Set the name to:** `${{ needs.secret-test.outputs.secret_name }}`
             5. **Set the value to:** Any non-empty value (e.g., `my-secret-value`, `hello-world`, etc.)
             6. **Click "Add secret"**
 
@@ -165,12 +194,12 @@ jobs:
             ```
             Repository Settings → Secrets and variables → Actions → New repository secret
 
-            Name: ${{ steps.check-secret.outputs.secret_name }}
+            Name: ${{ needs.secret-test.outputs.secret_name }}
             Secret: [Your chosen value - can be anything non-empty]
             ```
 
             **⚠️ Important Notes:**
-            - The secret name must be exactly `${{ steps.check-secret.outputs.secret_name }}` (case-sensitive)
+            - The secret name must be exactly `${{ needs.secret-test.outputs.secret_name }}` (case-sensitive)
             - The secret must have a non-empty value
             - Repository secrets are encrypted and secure
             - Only repository collaborators can view/edit secrets
@@ -187,7 +216,7 @@ jobs:
       # --- Additional step to validate secret content (optional) ---
       - name: Validate secret content
         id: validate-secret
-        if: steps.check-secret.outputs.secret_exists == 'true' && steps.find-issue.outputs.issue_found == 'true'
+        if: needs.secret-test.outputs.secret_exists == 'true' && needs.secret-test.outputs.issue_found == 'true'
         run: |
           SECRET_VALUE="${{ secrets.ASSIGNMENT_SECRET }}"
           SECRET_LENGTH=${#SECRET_VALUE}
@@ -218,11 +247,11 @@ jobs:
 
       # --- Comment if secret exists but is invalid ---
       - name: Comment on invalid secret content
-        if: steps.check-secret.outputs.secret_exists == 'true' && steps.validate-secret.outputs.validation_passed == 'false' && steps.find-issue.outputs.issue_found == 'true'
+        if: needs.secret-test.outputs.secret_exists == 'true' && steps.validate-secret.outputs.validation_passed == 'false' && needs.secret-test.outputs.issue_found == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ steps.find-issue.outputs.issue_number }}
+          issue-number: ${{ needs.secret-test.outputs.issue_number }}
           body: |
             ⚠️ **Secret Found But Invalid** ⚠️
 
@@ -230,11 +259,11 @@ jobs:
             **Triggered by:** @${{ github.actor }}
             **Workflow Dispatch:** ✅ Successfully used workflow_dispatch trigger
 
-            Your GitHub secret `${{ steps.check-secret.outputs.secret_name }}` exists, but it appears to contain only whitespace or empty content.
+            Your GitHub secret `${{ needs.secret-test.outputs.secret_name }}` exists, but it appears to contain only whitespace or empty content.
 
             **To fix this:**
             1. Go to Settings → Secrets and variables → Actions
-            2. Find the secret `${{ steps.check-secret.outputs.secret_name }}`
+            2. Find the secret `${{ needs.secret-test.outputs.secret_name }}`
             3. Click "Update"
             4. Enter a meaningful value (not just spaces)
             5. Save the changes


### PR DESCRIPTION
To address [issue 42 from the capstone course](https://github.com/fhdsl/reproducibility_capstone/issues/42), raised in [PR 41 in the same repo](https://github.com/fhdsl/reproducibility_capstone/pull/41), I did some debugging in a sandbox.

Related: [Sandbox PR #4 (Unsuccessful fixes mostly)](https://github.com/obigriffith/obigriffith-capstone-sandbox/pull/4), [Sandbox PR #5 (actually found the solution)](https://github.com/obigriffith/obigriffith-capstone-sandbox/pull/5), [Sandbox Issue #2 (successfully commented)](https://github.com/obigriffith/obigriffith-capstone-sandbox/issues/2)

Used the example of the GHA and Docker Evaluation workflows to set this up, but it splits the process into three distinct jobs using two containers. 

1. The first step evaluates whether the repo has a secret and creates or identifies an issue number for communicating the evaluation results. 
- needed to enumerate the outputs 

2. generates the code for the comment using the python script.
- this needed to be a separate step with a container with access to python. 
- needed to enumerate the output
- there's some logic that it will only generate the code if the repo secret was found

3. adds an issue comment detailing the result of the evaluation. 
- This uses the output of the previous two steps
- Uses the first container, not the python one.  

